### PR TITLE
Added libgpg-error.so as a lib to remove

### DIFF
--- a/steam-wrapper
+++ b/steam-wrapper
@@ -18,7 +18,7 @@
 ##
 # Wrapper wrapper_version
 ##
-wrapper_version=0.2.2
+wrapper_version=0.2.3
 
 # Script variables
 conf_location=
@@ -122,6 +122,7 @@ find_remove_stale_files()
     find "$1" \( -name "libgcc_s.so*" \
       -o -name "libasound.so*" \
       -o -name "libstdc++.so*" \
+      -o -name "libgpg-error.so" \
       -o -name "libxcb.so*" \) -print $2
   fi
 }


### PR DESCRIPTION
It's one of the libs in the wiki.
https://wiki.archlinux.org/index.php/Steam/Troubleshooting#Deleting_the_runtime_libraries